### PR TITLE
Update default path for asset directory

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -15,7 +15,7 @@ inputs:
     default: dist/worker/worker.js
   oxygen_assets_dir:
     description: The name of the assets directory
-    default: dist/client/assets
+    default: dist/client
   path:
     description: The root path of the project to deploy
 outputs:


### PR DESCRIPTION
We want the default path for the asset directory to be `dist/client` instead of `dist/client/assets`. We will need to re-release `v1`.

Closes #14 