### PR TITLE
`oxygenctl-action@v4`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,10 +60,7 @@ jobs:
           commit_timestamp: ${{ github.event.head_commit.timestamp }}
           oxygen_deployment_token: ${{ secrets.OXYGEN_DEPLOYMENT_TOKEN }}
           oxygen_dms_address: ${{ secrets.OXYGEN_DMS_ADDRESS }}
-          shop_id: ${{ secrets.OXYGEN_SHOP_ID }}
-          storefront_id: ${{ secrets.OXYGEN_STOREFRONT_ID }}
           path: ./hydrogen-app
-          workflow_run_id: ${{ github.run_id }}
           build_command: "HYDROGEN_ASSET_BASE_URL=$OXYGEN_ASSET_BASE_URL yarn build"
 
       - name: Output check

--- a/action.yml
+++ b/action.yml
@@ -4,12 +4,6 @@ branding:
   colour: green
 description: 'Deploy JavaScript applications to Shopify Oxygen directly from GitHub'
 inputs:
-  shop_id:
-    description: The Shop ID
-    required: true
-  storefront_id:
-    description: The Storefront ID
-    required: true
   build_command:
     description: The build command to execute; OXYGEN_ASSET_BASE_URL is available as a reference to Shopify's CDN for this command
     required: true
@@ -35,10 +29,6 @@ inputs:
     default: dist/client
   path:
     description: The root path of the project to deploy
-  workflow_run_id:
-    description: The id of the workflow run
-    default: ${{ github.run_id }}
-    required: true
 outputs:
   url:
     description: URL of the deployment
@@ -50,8 +40,6 @@ runs:
       id: 'oxygenctl-action'
       shell: 'bash'
       env:
-        INPUT_SHOP_ID: ${{ inputs.shop_id }}
-        INPUT_STOREFRONT_ID: ${{ inputs.storefront_id }}
         INPUT_BUILD_COMMAND: ${{ inputs.build_command }}
         INPUT_COMMIT_MESSAGE: ${{ inputs.commit_message }}
         INPUT_COMMIT_TIMESTAMP: ${{ inputs.commit_timestamp }}
@@ -60,4 +48,3 @@ runs:
         INPUT_OXYGEN_WORKER_DIR: ${{ inputs.oxygen_worker_dir }}
         INPUT_OXYGEN_CLIENT_DIR: ${{ inputs.oxygen_client_dir }}
         INPUT_PATH: ${{ inputs.path }}
-        INPUT_WORKFLOW_RUN_ID: ${{ inputs.workflow_run_id }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,16 +9,11 @@ set -eu
 export OXYGEN_DEPLOYMENT_TOKEN="$INPUT_OXYGEN_DEPLOYMENT_TOKEN"
 export OXYGEN_COMMIT_MESSAGE="$INPUT_COMMIT_MESSAGE"
 export OXYGEN_COMMIT_TIMESTAMP="$INPUT_COMMIT_TIMESTAMP"
-export OXYGEN_WORKFLOW_ID="$INPUT_WORKFLOW_RUN_ID"
-export OXYGEN_SHOP_ID="$INPUT_SHOP_ID"
-export OXYGEN_STOREFRONT_ID="$INPUT_STOREFRONT_ID"
 export OXYGEN_BUILD_COMMAND="$INPUT_BUILD_COMMAND"
+export OXYGEN_WORKFLOW_ID="${GITHUB_RUN_ID}_${GITHUB_RUN_ATTEMPT}"
 
 oxygenctl_bin="$(dirname $0)/oxygenctl"
 
-$oxygenctl_bin --version
-
-# Temporarily ignoring that successful deploys result in 502s, that's why we || true
 preview_url="$(
   $oxygenctl_bin deploy \
     --assets-dir "$INPUT_OXYGEN_CLIENT_DIR" \
@@ -26,5 +21,4 @@ preview_url="$(
     --dms-address "$INPUT_OXYGEN_DMS_ADDRESS"
 )"
 
-# Hardcoded storefont name for now
 echo "::set-output name=url::$preview_url"


### PR DESCRIPTION
This PR:
- Introduces a `v4` to `oxygenctl-action` and updates the action's `oxygenctl` binary to `v3`. This breaking change removes the `shop_id`, `storefront_id` and `workflow_run_id` inputs, as they as no longer necessary. See https://github.com/Shopify/oxygenctl/pull/70 for more details.
- Changes the format of the workflow ID to be a combination of the `workflow_run_id` and the `workflow_run_attempt`. This is done so that a unique ID is generated on every GitHub workflow re-run, which causes every rerun to be treated as a new deployment. We'll start depending on the `v4` tag at the same time as a change to use the new workflow ID format to query Oxygen for deployments.