### PR TITLE
Fix health check flag

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,7 +4,7 @@ if [[ -n "$INPUT_PATH" ]]; then
 fi
 
 # Bail on first non-zero exist status, and bail any referenced variable is unset.
-set -eu 
+set -eu
 
 export OXYGEN_DEPLOYMENT_TOKEN="$INPUT_OXYGEN_DEPLOYMENT_TOKEN"
 export OXYGEN_COMMIT_MESSAGE="$INPUT_COMMIT_MESSAGE"
@@ -14,12 +14,18 @@ export OXYGEN_WORKFLOW_ID="${GITHUB_RUN_ID}_${GITHUB_RUN_ATTEMPT}"
 
 oxygenctl_bin="$(dirname $0)/oxygenctl"
 
+oxygenctl_args=(
+    --assets-dir "$INPUT_OXYGEN_CLIENT_DIR"
+    --worker-dir "$INPUT_OXYGEN_WORKER_DIR"
+    --dms-address "$INPUT_OXYGEN_DMS_ADDRESS"
+)
+
+if [[ "$INPUT_OXYGEN_HEALTH_CHECK" = "true" ]]; then
+    oxygenctl_args+=(--health-check)
+fi
+
 preview_url="$(
-  $oxygenctl_bin deploy \
-    --assets-dir "$INPUT_OXYGEN_CLIENT_DIR" \
-    --worker-dir "$INPUT_OXYGEN_WORKER_DIR" \
-    --dms-address "$INPUT_OXYGEN_DMS_ADDRESS" \
-    --health-check "$INPUT_OXYGEN_HEALTH_CHECK"
+  $oxygenctl_bin deploy "${oxygenctl_args[@]}"
 )"
 
 echo "::set-output name=url::$preview_url"


### PR DESCRIPTION
Viper ignores the argument passed to boolean flags.  Instead it's only checking for the presence of the flag.