### PR TITLE
Use deployment check rather than /__health check

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -28,7 +28,7 @@ inputs:
     description: The name of the directory with compiled client files
     default: dist/client
   oxygen_health_check:
-    description: Perform a health check at `/__health` before marking deployment as successful? (`true` or `false`)
+    description: Ensure the application is reachable on Oxygen marking deployment as successful? (`true` or `false`)
     default: false
   path:
     description: The root path of the project to deploy


### PR DESCRIPTION
This PR updates the version of `oxygenctl` to use the special `/.oxygen/deployment` route, which checks that the application is deployed and ready to receive traffic rather than resolving the application's `/__health` route.