### PR TITLE
Capture background process exit code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,22 +26,23 @@ jobs:
           npm --version
           npm create @shopify/hydrogen@latest -- --template hello-world --language ts --path hydrogen-app --install-deps false
 
-      - name: Get yarn cache directory
-        id: yarn-cache-dir-path
-        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
-
-      - uses: actions/cache@v3
+      - name: Cache node modules
+        id: cache-npm
+        uses: actions/cache@v3
+        env:
+          cache-name: cache-node-modules
         with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          path: ~/.npm
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
-            ${{ runner.os }}-yarn-
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
 
       - name: Install dependencies
-        id: "install-dependencies"
         run: |
           cd hydrogen-app
-          yarn
+          npm install
 
       - name: Deploy to Oxygen
         uses: ./

--- a/action.yml
+++ b/action.yml
@@ -99,6 +99,12 @@ runs:
       run: |
         [[ -n "${{ inputs.path }}" ]] && cd "${{ inputs.path }}"
 
+        # We need to run multiple processes at once and are going to handle
+        # exiting manually
+        set +e
+
+        pids=()
+
         if [ "${{ env.IS_V2 }}" == "true" ]; then
           mkdir oxygen_v2
           rsync -a ./* ./oxygen_v2/ --exclude 'oxygen_v2' --exclude 'node_modules'
@@ -117,11 +123,22 @@ runs:
             fi
 
             if [[ "${{ env.PRIORITY }}" == "v2" ]]; then
-              echo "url=$(cd oxygen_v2 && ln -s ../node_modules node_modules && $oxygen_v2_command --buildCommand="${build_command_filtered}" )" >> $GITHUB_OUTPUT
+              output=$(cd oxygen_v2 && ln -s ../node_modules node_modules && $oxygen_v2_command --buildCommand="${build_command_filtered}")
+              exit_code=$?
+
+              if [ $exit_code -eq 0 ]; then
+                echo "url=$output" >> $GITHUB_OUTPUT
+              else
+                exit $exit_code
+              fi
             else
               $(cd oxygen_v2 && ln -s ../node_modules node_modules && $oxygen_v2_command --buildCommand="${build_command_filtered}" &> /dev/null)
             fi
           } &
+          pids+=($!)
+          if [[ "${{ env.PRIORITY }}" == "v2" ]]; then
+            priority_pid=$!
+          fi
         fi
 
         if [ "${{ env.IS_V1 }}" == "true" ]; then
@@ -129,12 +146,35 @@ runs:
             echo "Deploying to Oxygen..."
             [[ -z "${{ inputs.commit_timestamp }}" ]] && export OXYGEN_COMMIT_TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ") || export OXYGEN_COMMIT_TIMESTAMP=${{ inputs.commit_timestamp }}
             oxygen_v1_command="$GITHUB_ACTION_PATH/oxygenctl deploy --health-check=${{ inputs.oxygen_health_check }}"
+
             if [[ "${{ env.PRIORITY }}" == "v1" ]]; then
-              echo "url=$(OXYGEN_DEPLOYMENT_TOKEN=${{ steps.check_version.outputs.v1_token }} $oxygen_v1_command)" >> $GITHUB_OUTPUT
+              output=$(OXYGEN_DEPLOYMENT_TOKEN=${{ steps.check_version.outputs.v1_token }} $oxygen_v1_command)
+              exit_code=$?
+
+              if [ $exit_code -eq 0 ]; then
+                echo "url=$output" >> $GITHUB_OUTPUT
+              else
+                exit $exit_code
+              fi
             else
               $(OXYGEN_DEPLOYMENT_TOKEN=${{ steps.check_version.outputs.v1_token }} $oxygen_v1_command &> /dev/null)
             fi
           } &
+          pids+=($!)
+          if [[ "${{ env.PRIORITY }}" == "v1" ]]; then
+            priority_pid=$!
+          fi
         fi
 
-        wait
+        priority_exit_code=0
+
+        for pid in ${pids[*]}; do
+          wait $pid
+          exit_status=$?
+
+          if [ $pid -eq $priority_pid ]; then
+            priority_exit_code=$exit_status
+          fi
+        done
+
+        exit $priority_exit_code


### PR DESCRIPTION
This PR does two things:

1. Switches this repo's CI to use `npm` instead of `yarn` to remove the multiple lockfile warning from the workflow process
2. Updates `wait` to loop over the background processes and return the priority processes's PID as our exit code. Right now the exit code is only happening in a background process so it could fail but GitHub reports the step as successful. This has been confusing developers because the failure ends up in the wrong spot in their actions.