### PR TITLE
Revert "Change default health check back to false"

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -26,7 +26,7 @@ inputs:
     default: dist/client
   oxygen_health_check:
     description: Ensure the application is reachable on Oxygen marking deployment as successful? (`true` or `false`)
-    default: false
+    default: true
   oxygen_health_check_max_duration:
     description: The maximum duration in seconds to wait for the health check to pass
     default: 180


### PR DESCRIPTION
Reverts Shopify/oxygenctl-action#58

We've fixed the issue that was causing incorrect health check failures, so I'm reverting the change back to health check defaulting to false.

A failed health check **does not mean the deployment failed**. It does however mean that there could be a problem with _accessing_ the deployment via the preview url. The admin will reflect the state of the deployment, **not** the health of the deployment. IE: if something was deployed, but not accessible, it will still be considered a successful deployment in the admin. 