### PR TITLE
rename health check

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This action accepts the following inputs:
 - `oxygen_deployment_token`: The Oxygen deployment token issued by Shopify. This is a required input.
 - `oxygen_worker_dir`: The name of the directory containing the worker file. Defaults to `dist/worker`.
 - `oxygen_client_dir`: The name of the directory with compiled asset files to be uploaded to the CDN. Defaults to `dist/client`.
-- `oxygen_health_check`: Determines whether to ensure the preview url is accessible on Oxygen before marking the workflow as successful. This does **not** mean the deployment wasn't successful, but that the page may not be loading properly. The deployment status in the Hydrogen Storefronts channel will reflect the status of the deployment, not the health of the deployment. Accepts `true` or `false`. Defaults to `true`.
+- `oxygen_deployment_verification`: Verifies successful deployment of the worker to Oxygen. Accepts `true` or `false`. Defaults to `true`. Note: This verification checks the status of the deployment, not the health of the application. If set to `true`, the workflow will only be marked as successful if the worker deployment to Oxygen has been verified to be routable. Also note that the workflow status and the status of the deployment in the Hydrogen storefronts channel may differ if the verification check fails.
 - `path`: The root path of the project to deploy.
 
 ### Output

--- a/action.yml
+++ b/action.yml
@@ -24,10 +24,10 @@ inputs:
   oxygen_client_dir:
     description: The name of the directory with compiled client files
     default: dist/client
-  oxygen_health_check:
-    description: Ensure the application is reachable on Oxygen marking deployment as successful? (`true` or `false`)
+  oxygen_deployment_verification:
+    description: Verify the worker deployment to Oxygen has been completed (`true` or `false`)
     default: true
-  oxygen_health_check_max_duration:
+  oxygen_deployment_verification_max_duration:
     description: The maximum duration in seconds to wait for the health check to pass
     default: 180
   path:
@@ -116,10 +116,10 @@ runs:
                   --path=${{ inputs.path }} \
                   --assetsFolder=${{ inputs.oxygen_client_dir }} \
                   --workerFolder=${{ inputs.oxygen_worker_dir }} \
-                  --healthCheckMaxDuration=${{ inputs.oxygen_health_check_max_duration }} \
+                  --verificationMaxDuration=${{ inputs.oxygen_deployment_verification_max_duration }} \
                   --token=${{ steps.check_version.outputs.v2_token }}"
-            if [ "${{ inputs.oxygen_health_check }}" == "false" ]; then
-              oxygen_v2_command+=" --skipHealthCheck"
+            if [ "${{ inputs.oxygen_deployment_verification }}" == "false" ]; then
+              oxygen_v2_command+=" --skipVerification"
             fi
 
             if [[ "${{ env.PRIORITY }}" == "v2" ]]; then
@@ -145,7 +145,7 @@ runs:
           {
             echo "Deploying to Oxygen..."
             [[ -z "${{ inputs.commit_timestamp }}" ]] && export OXYGEN_COMMIT_TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ") || export OXYGEN_COMMIT_TIMESTAMP=${{ inputs.commit_timestamp }}
-            oxygen_v1_command="$GITHUB_ACTION_PATH/oxygenctl deploy --health-check=${{ inputs.oxygen_health_check }}"
+            oxygen_v1_command="$GITHUB_ACTION_PATH/oxygenctl deploy --deployment-verification=${{ inputs.oxygen_deployment_verification }}"
 
             if [[ "${{ env.PRIORITY }}" == "v1" ]]; then
               output=$(OXYGEN_DEPLOYMENT_TOKEN=${{ steps.check_version.outputs.v1_token }} $oxygen_v1_command)


### PR DESCRIPTION
We need to keep the `inputs.oxygen_health_check` for backwards compatibility but can introduce a new input too, and use a variable to get our boolean.

Updates the action with the revised inputs from:
- https://github.com/Shopify/oxygenctl/pull/218
- https://github.com/Shopify/oxygen-cli/pull/252

Updates the Readme and oxygenctl binary, too.