### PR TITLE
Add support for dot files during build on V2

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -108,7 +108,7 @@ runs:
 
         if [ "${{ env.IS_V2 }}" == "true" ]; then
           mkdir oxygen_v2
-          rsync -a ./* ./oxygen_v2/ --exclude 'oxygen_v2' --exclude 'node_modules'
+          rsync -a ./ ./oxygen_v2/ --exclude 'oxygen_v2' --exclude 'node_modules'
           {
             echo "Deploying to Oxygen..."
             build_command_filtered=$(echo '${{ inputs.build_command }}' | sed 's/HYDROGEN_ASSET_BASE_URL=$OXYGEN_ASSET_BASE_URL //g')


### PR DESCRIPTION
Closes https://github.com/Shopify/oxygen-platform/issues/1387

Add support for the usage of .env files for V2 builds