### PR TITLE
remove path flag for oxygen-cli

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -113,7 +113,6 @@ runs:
             echo "Deploying to Oxygen..."
             build_command_filtered=$(echo '${{ inputs.build_command }}' | sed 's/HYDROGEN_ASSET_BASE_URL=$OXYGEN_ASSET_BASE_URL //g')
             oxygen_v2_command="npx @shopify/oxygen-cli@latest oxygen:deploy \
-                  --path=${{ inputs.path }} \
                   --assetsFolder=${{ inputs.oxygen_client_dir }} \
                   --workerFolder=${{ inputs.oxygen_worker_dir }} \
                   --verificationMaxDuration=${{ inputs.oxygen_deployment_verification_max_duration }} \


### PR DESCRIPTION
We are already `cd` into the `path` when that option is present ([here](https://github.com/Shopify/oxygenctl-action/blob/d3adc1115b4a160aa384371c4c15b97d1ce13e3f/action.yml#L101C9-L101C65)) so the `path` argument when calling `oxygen-cli` would cause a "path not found" error.
