### PR TITLE
Make verification check default to false until we fix the route

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -26,7 +26,7 @@ inputs:
     default: dist/client
   oxygen_deployment_verification:
     description: Verify the worker deployment to Oxygen has been completed (`true` or `false`)
-    default: true
+    default: false
   oxygen_deployment_verification_max_duration:
     description: The maximum duration in seconds to wait for the health check to pass
     default: 180


### PR DESCRIPTION
We made a check that broke the verification route this morning, we are working to fix it, but this will stop workflows from failing until we do.

Deployments are actually fine, so this is misleading.