### PR TITLE
Select version 2.6.2 of oxygen-cli

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -73,7 +73,7 @@ runs:
       run: |
         echo "Deploying to Oxygen..."
         build_command_filtered=$(echo '${{ inputs.build_command }}' | sed 's/HYDROGEN_ASSET_BASE_URL=$OXYGEN_ASSET_BASE_URL //g')
-        oxygen_command="npm exec --package=@shopify/oxygen-cli@latest -- oxygen-cli oxygen:deploy \
+        oxygen_command="npm exec --package=@shopify/oxygen-cli@2.6.2 -- oxygen-cli oxygen:deploy \
               --path=${{ inputs.path }} \
               --assetsFolder=${{ inputs.oxygen_client_dir }} \
               --workerFolder=${{ inputs.oxygen_worker_dir }} \


### PR DESCRIPTION
oxygenctl-action can't parse oxygen-cli's new JSON format. Using previous version of CLI until patched