### PR TITLE
Bump version of oxygen cli to 3.1.1

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -73,7 +73,7 @@ runs:
       run: |
         echo "Deploying to Oxygen..."
         build_command_filtered=$(echo '${{ inputs.build_command }}' | sed 's/HYDROGEN_ASSET_BASE_URL=$OXYGEN_ASSET_BASE_URL //g')
-        oxygen_command="npm exec --package=@shopify/oxygen-cli@3.1.0 -- oxygen-cli oxygen:deploy \
+        oxygen_command="npm exec --package=@shopify/oxygen-cli@3.1.1 -- oxygen-cli oxygen:deploy \
               --path=${{ inputs.path }} \
               --assetsFolder=${{ inputs.oxygen_client_dir }} \
               --workerFolder=${{ inputs.oxygen_worker_dir }} \


### PR DESCRIPTION
Adds changes to verify deployment completion before attempting checking if it is routable and fail early when the deployment has failed.

https://github.com/Shopify/oxygen-cli/pull/362