### PR TITLE
use oxygen-cli 3.1.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,9 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Setup node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: "16"
+          node-version: "18"
           check-latest: true
 
       - name: Setup bot Git user

--- a/action.yml
+++ b/action.yml
@@ -73,7 +73,7 @@ runs:
       run: |
         echo "Deploying to Oxygen..."
         build_command_filtered=$(echo '${{ inputs.build_command }}' | sed 's/HYDROGEN_ASSET_BASE_URL=$OXYGEN_ASSET_BASE_URL //g')
-        oxygen_command="npm exec --package=@shopify/oxygen-cli@3.1.1 -- oxygen-cli oxygen:deploy \
+        oxygen_command="npm exec --package=@shopify/oxygen-cli@3.1.5 -- oxygen-cli oxygen:deploy \
               --path=${{ inputs.path }} \
               --assetsFolder=${{ inputs.oxygen_client_dir }} \
               --workerFolder=${{ inputs.oxygen_worker_dir }} \


### PR DESCRIPTION
Bumps oxygen-cli to the latest stable version.

EDIT: also bumped the workflow to deploy `hello-world` to oxygen to use setup-node v4 and consequently Node 18, as Hydrogen now looks to require this.