### PR TITLE
add pnpm logic

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -73,12 +73,20 @@ runs:
       run: |
         echo "Deploying to Oxygen..."
         build_command_filtered=$(echo '${{ inputs.build_command }}' | sed 's/HYDROGEN_ASSET_BASE_URL=$OXYGEN_ASSET_BASE_URL //g')
-        oxygen_command="npm exec --package=@shopify/oxygen-cli@4 -- oxygen-cli oxygen:deploy \
-              --path=${{ inputs.path }} \
-              --assetsFolder=${{ inputs.oxygen_client_dir }} \
-              --workerFolder=${{ inputs.oxygen_worker_dir }} \
-              --verificationMaxDuration=${{ inputs.oxygen_deployment_verification_max_duration }} \
-              --token=${{ steps.check_version.outputs.token }}"
+  
+        if command -v pnpm > /dev/null 2>&1; then
+          exec_command="pnpm dlx @shopify/oxygen-cli@4"
+        else
+          exec_command="npm exec --package=@shopify/oxygen-cli@4 -- oxygen-cli"
+        fi
+
+        oxygen_command="$exec_command oxygen:deploy \
+          --path=${{ inputs.path }} \
+          --assetsFolder=${{ inputs.oxygen_client_dir }} \
+          --workerFolder=${{ inputs.oxygen_worker_dir }} \
+          --verificationMaxDuration=${{ inputs.oxygen_deployment_verification_max_duration }} \
+          --token=${{ steps.check_version.outputs.token }}"
+
         if [ "${{ inputs.oxygen_deployment_verification }}" == "false" ]; then
           oxygen_command+=" --skipVerification"
         fi


### PR DESCRIPTION
Merchants using `pnpm` are seeing an error `sh: 1: oxygen-cli: not found` since we bumped the version of `oxygen-cli` in the action to v4.

I'm not fully understanding what's happening, but I can replicate this on my side too. Installing the dependencies of a project with `pnpm` instead of `npm` and consequently calling `oxygen-cli` with `npm exec` seems to be problematic.

My guess is that `oxygen-cli` v4 already is an indirect dependency of the project (through Hydrogen) and that when installing dependencies with `pnpm` it's installed. However, pnpm does not install these in the `PATH` and we get that error when `npm exec` consequently decides it does not need to install, but can just run it.

The most stable workaround that I can think of, is using `pnpm dlx` over `npm exec` when the `pnpm` command can be resolved. In my testing, this worked correctly.