### PR TITLE
remove token check step

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -43,29 +43,6 @@ outputs:
 runs:
   using: 'composite'
   steps:
-    - name: Check Oxygen version
-      shell: 'bash'
-      id: check_version
-      run: |
-        TOKEN="${{ inputs.oxygen_deployment_token }}"
-        echo "::add-mask::$TOKEN"
-
-        if [[ "${TOKEN}" == *":"* ]]; then
-          echo "Multi token"
-          IFS=':' read -ra token_list <<< "${TOKEN}"
-          token=${token_list[1]}
-          echo "::add-mask::$token"
-          echo "token=$token" >> $GITHUB_OUTPUT
-        else
-          if [[ "${TOKEN}" =~ ^[A-Za-z0-9+/]+[=]{0,2}$ ]]; then
-            echo "Token is in V2 format"
-            echo "token=${TOKEN}" >> $GITHUB_OUTPUT
-          else
-            echo "Your repository is out of date, please disconnect and reconnect your storefront on Shopify"
-            exit 1
-          fi
-        fi
-
     - name: Build and Publish to Oxygen
       shell: 'bash'
       id: 'oxygen-cli-action'
@@ -79,7 +56,7 @@ runs:
               --assetsFolder=${{ inputs.oxygen_client_dir }} \
               --workerFolder=${{ inputs.oxygen_worker_dir }} \
               --verificationMaxDuration=${{ inputs.oxygen_deployment_verification_max_duration }} \
-              --token=${{ steps.check_version.outputs.token }}"
+              --token=${{ inputs.oxygen_deployment_token }}"
         if [ "${{ inputs.oxygen_deployment_verification }}" == "false" ]; then
           oxygen_command+=" --skipVerification"
         fi


### PR DESCRIPTION
This step is no longer needed and the regex is potentially incorrect, considering some tokens invalid.

Initially this wasn't working and I figured out why I was having issues, this repo has a manually entered token and was not updated to V2 format, so using the input directly was causing an issue. I've updated the token now and it's happy, but there is still another issue with CI unrelated to this.

<img width="189" alt="image" src="https://github.com/Shopify/oxygenctl-action/assets/12747574/e027695d-e2bc-4460-b6ef-aa81affdce4b">
