### PR TITLE
Scaffold Hydrogen demo store instead of hello world template in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Create a Hydrogen app
         run: |
-          npm create @shopify/hydrogen@latest -- --template hello-world --language ts --path hydrogen-app --install-deps true
+          npm create @shopify/hydrogen@latest -- --template demo-store --language ts --path hydrogen-app --install-deps true
 
       - name: Cache node modules
         id: cache-npm


### PR DESCRIPTION
Dependency of https://github.com/Shopify/hydrogen/pull/2216

I'd like to delete Hydrogen's outdated Hello World template, but it would break this CI workflow. This PR updates the Hydrogen project-creation step to use the Demo Store template instead.