### PR TITLE
add usage metric

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -43,6 +43,13 @@ outputs:
 runs:
   using: 'composite'
   steps:
+    - name: Collect metrics
+      shell: 'bash'
+      run: |
+        endpoint="https://metrics.myshopify.dev"
+        metric='{"events":[{"name": "oxygen_platform.oxygenctl_action_usage", "type": "count", "value": 1}]}'
+        curl -s -X POST -H "Content-Type: application/json" -d "$metric" "$endpoint"
+
     - name: Build and Publish to Oxygen
       shell: 'bash'
       id: 'oxygen-cli-action'


### PR DESCRIPTION
Adds a simple counter metric to the action, to allow us to monitor usage of the action prior to its EOL, sent to the metrics worker.